### PR TITLE
Make satchel no_std

### DIFF
--- a/crates/satchel/src/lib.rs
+++ b/crates/satchel/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub use satchel_macro::{bench, test};
 
 pub type TestFn = fn();
@@ -34,12 +36,11 @@ pub fn extract_crate_name(module_path: &str) -> &str {
 }
 
 #[doc(hidden)]
-pub fn get_tests_for_crate(crate_prefix: &str) -> Vec<&'static TestCase> {
+pub fn get_tests_for_crate(crate_prefix: &str) -> impl Iterator<Item = &'static TestCase> {
     let crate_name = extract_crate_name(crate_prefix);
     test_harness::TESTS
         .iter()
-        .filter(|case| case.module_path.starts_with(crate_name))
-        .collect()
+        .filter(move |case| case.module_path.starts_with(crate_name))
 }
 
 #[macro_export]

--- a/examples/rust-examples/satchel-demo/tests/satchel_demo.rs
+++ b/examples/rust-examples/satchel-demo/tests/satchel_demo.rs
@@ -1,18 +1,16 @@
 use libtest_mimic::{Arguments, Failed, Trial};
 use std::panic;
+use satchel::TestCase;
 
 pub fn discover_and_run() -> bool {
-    let tests_ref = satchel::get_tests!();
-    let tests: Vec<satchel::test_harness::TestCase> = tests_ref.into_iter().cloned().collect();
+    let tests = satchel::get_tests!();
 
     let args = Arguments::from_args();
-    run_tests(&tests, args)
+    run_tests(tests, args)
 }
 
-fn run_tests(tests: &[satchel::test_harness::TestCase], args: Arguments) -> bool {
+fn run_tests(tests: impl Iterator<Item=&'static TestCase>, args: Arguments) -> bool {
     let trials: Vec<Trial> = tests
-        .iter()
-        .cloned()
         .map(|case| {
             let kind_str = format!("{:?}", case.kind);
             let full_name = format!("{}::{}", case.module_path, case.name);


### PR DESCRIPTION
Makes the satchel main lib no_std, by removing the usage of std::vec::Vec. Instead, it now passes an iterator around.

Also simply the example by avoiding operations that were mostly type adlustments.